### PR TITLE
cmake-no-system win-arm64 support

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,4 @@
 
-if "%ARCH%"=="32" (set CPU_ARCH=x86) else (set CPU_ARCH=x64)
 set PATH=%CD%\cmake-bin\bin;%PATH%
 cmake --version
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,16 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://gitlab.kitware.com/cmake/cmake/-/archive/v{{ version }}/cmake-v{{ version }}.tar.bz2
-    sha256: 21001a52f2a2068025c17597f8144e4976d6bcd20fa7d340431f004be30767b9
-    folder: cmake
 
-  # build cmake with itself on Windows
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86_64.zip  # [win64]
-    sha256: d129425d569140b729210f3383c246dec19c4183f7d0afae1837044942da3b4b  # [win64]
-    folder: cmake-bin  # [win64]
+  - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}.tar.gz
+    sha256: cc995701d590ca6debc4245e9989939099ca52827dd46b5d3592f093afe1901c
+    folder: cmake
+  - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}-windows-x86_64.zip  # [win and x86_64]
+    sha256: 109c29a744d648863d3637b4963c90088045c8d92799c68c9b9d8713407776c8  # [win and x86_64]
+    folder: cmake-bin  # [win and x86_64]
+  - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}-windows-arm64.zip  # [win and arm64]
+    sha256: 3498fea26257eebfbfc89ed17963f3d8d83c19362b90fb23517842de777a522a  # [win and arm64]
+    folder: cmake-bin  # [win and arm64]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "cmake-no-system" %}
 {% set version = "4.3.2" %}
-{% set posix = 'm2-' if win else '' %}
 
 package:
   name: {{ name|lower }}
@@ -20,7 +19,6 @@ source:
 
 build:
   number: 1
-  skip: True  # [win and vc<14]
   detect_binary_files_with_prefix: False
   ignore_run_exports:
     - vc
@@ -30,7 +28,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ posix }}make
+    - make  # [unix]
     - jom  # [win]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     folder: cmake-bin  # [win and arm64]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   detect_binary_files_with_prefix: False
   ignore_run_exports:


### PR DESCRIPTION
cmake-no-system rebuild

**Destination channel:** defaults

### Links

- [PKG-15374](https://anaconda.atlassian.net/browse/PKG-15374) 

### Explanation of changes:

- Add win-arm64 source urls
- bump build number. 
- Remove m2-patch that wasn't used
- No need to set `CPU_ARCH`
- FIx lints


[PKG-15374]: https://anaconda.atlassian.net/browse/PKG-15374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ